### PR TITLE
fix: pass 'syninfo' attribute to criteria use in spaCy lemmatization component

### DIFF
--- a/dwdsmor/spacy.py
+++ b/dwdsmor/spacy.py
@@ -23,11 +23,14 @@ def lemmatize_token(lemmatizer: Lemmatizer, token: Token):
         morph(token_morph, "Number"),
         morph(token_morph, "Gender"),
         morph(token_morph, "Case"),
-        morph(token_morph, "Person"),
+        morph(token_morph, "Person") or "UnmPers"
+        if token.dep_ == "compound:prt"
+        else None,
         morph(token_morph, "Tense"),
         morph(token_morph, "Degree"),
         morph(token_morph, "Mood"),
         morph(token_morph, "VerbForm"),
+        "SEP" if token.dep_ == "compound:prt" else None,
     )
     token._.dwdsmor = lemmatizer(token.text, **token_criteria)
     return token

--- a/test/test_spacy.py
+++ b/test/test_spacy.py
@@ -48,3 +48,29 @@ def test_lemmatisation(nlp, sentences, snapshot):
         if t._.dwdsmor and t.lemma_ != t._.dwdsmor.analysis
     )
     assert tuple(tokens) == snapshot
+
+
+@if_dwds_available
+def test_particle_lemmatization(nlp):
+    sentences = [
+        "Sie nimmt nicht an der Wahl teil.",
+        "Wir arbeiten dennoch weiter.",
+    ]
+    docs = nlp.pipe(sentences)
+    tokens = [[t._.dwdsmor.analysis for t in doc] for doc in docs]
+    docs_without_dep = nlp.pipe(sentences, disable="parser")
+    tokens_without_dep = [
+        [t._.dwdsmor.analysis for t in doc] for doc in docs_without_dep
+    ]
+    expected = [
+        ["sie", "nehmen", "nicht", "an", "die", "Wahl", "teil", "."],
+        [
+            "wir",
+            "arbeiten",
+            "dennoch",
+            "weiter",
+            ".",
+        ],
+    ]
+    assert tokens == expected
+    assert tokens != tokens_without_dep


### PR DESCRIPTION
Using information from dependency annotation for particle lemmatization yields better results for lemma.