### PR TITLE
Use minimal word formation boundaries for lemma disambiguation

### DIFF
--- a/dwdsmor/__init__.py
+++ b/dwdsmor/__init__.py
@@ -169,9 +169,19 @@ class Lemmatizer:
             attr, attr_vals = criteria_stack.pop()
             filtered = tuple((t for t in traversals if getattr(t, attr) in attr_vals))
             traversals = filtered or traversals
+        if len(traversals) == 1:
+            return traversals[0]
         traversals = sorted(
-            traversals, key=lambda t: -self.lemma_freqs.get(t.analysis, 0)
+            traversals, key=lambda t: t.wb_count(wf_boundary_tags="#|-")
         )
+        traversals_with_ppm = [
+            (t, f)
+            for t in traversals
+            if (f := (-self.lemma_freqs.get(t.analysis, -1))) < 0
+        ]
+        traversals_with_ppm = sorted(traversals_with_ppm, key=lambda t: t[1])
+        if traversals_with_ppm:
+            return traversals_with_ppm[0][0]
         for traversal in traversals:
             return traversal
 

--- a/dwdsmor/traversal.py
+++ b/dwdsmor/traversal.py
@@ -90,3 +90,15 @@ class Traversal:
             elif not k:
                 surface += v
         return Traversal(spec, surface, analysis, **tags)
+
+    def wb_count(self, wf_boundary_tags="", boundary_tag=None):
+        return sum(
+            [
+                self.spec.count(
+                    f"{boundary_tag}{b}{boundary_tag}"
+                    if boundary_tag is not None
+                    else f"<{b}>"
+                )
+                for b in wf_boundary_tags
+            ]
+        )

--- a/dwdsmor/traversal.py
+++ b/dwdsmor/traversal.py
@@ -91,14 +91,5 @@ class Traversal:
                 surface += v
         return Traversal(spec, surface, analysis, **tags)
 
-    def wb_count(self, wf_boundary_tags="", boundary_tag=None):
-        return sum(
-            [
-                self.spec.count(
-                    f"{boundary_tag}{b}{boundary_tag}"
-                    if boundary_tag is not None
-                    else f"<{b}>"
-                )
-                for b in wf_boundary_tags
-            ]
-        )
+    def wb_count(self, wf_boundary_tags=""):
+        return sum([self.spec.count(f"<{b}>") for b in wf_boundary_tags])

--- a/test/test_lemmatizer.py
+++ b/test/test_lemmatizer.py
@@ -19,3 +19,16 @@ def test_lemmatizer(lemmatizer):
 def test_ptkvz_lemmatization(lemmatizer):
     assert lemmatizer("besser", pos={"V"}, syninfo={"SEP"}).analysis == "besser"
     assert lemmatizer("besser", pos={"ADJ"}).analysis == "gut"
+
+
+@if_dwds_available
+def test_lemmatizer_for_word_in_ppm_table(lemmatizer):
+    assert lemmatizer("Puls", pos={"NN"}).analysis == "Puls"
+
+
+@if_dwds_available
+def test_lemmatizer_with_minimal_wfb(lemmatizer):
+    assert (
+        lemmatizer("Berufssoldaten", pos={"NN"}, number={"Pl"}).analysis
+        == "Berufssoldat"
+    )

--- a/test/test_traversal.py
+++ b/test/test_traversal.py
@@ -1,0 +1,98 @@
+from dwdsmor import Traversal
+
+
+def test_wb_count():
+    t = Traversal(
+        spec="Beruf<~>s<#>soldat<NN><Masc><Dat><Pl>",
+        surface="Berufssoldat",
+        analysis="Berufssoldat",
+        weights=None,
+        lidx=None,
+        pidx=None,
+        pos="NN",
+        category=None,
+        degree=None,
+        function=None,
+        person=None,
+        gender="Masc",
+        case="Dat",
+        number="Pl",
+        nonfinite=None,
+        tense=None,
+        mood=None,
+        auxiliary=None,
+        inflection=None,
+        metainfo=None,
+        orthinfo=None,
+        charinfo=None,
+        syninfo=None,
+        ellipinfo=None,
+        processes=None,
+        means=None,
+    )
+    assert t.wb_count("#") == 1
+
+
+def test_wb_count_ignore_symbols_not_in_boundary_tag():
+    t = Traversal(
+        spec="UN<=>-<#>Sicherheit<~>s<#>rat<NN><Masc><Dat><Sg>",
+        surface="UN-Sicherheitsrat",
+        analysis="UN-Sicherheitsrat",
+        weights=None,
+        lidx=None,
+        pidx=None,
+        pos="NN",
+        category=None,
+        degree=None,
+        function=None,
+        person=None,
+        gender="Masc",
+        case="Dat",
+        number="Sg",
+        nonfinite=None,
+        tense=None,
+        mood=None,
+        auxiliary=None,
+        inflection=None,
+        metainfo=None,
+        orthinfo=None,
+        charinfo=None,
+        syninfo=None,
+        ellipinfo=None,
+        processes=None,
+        means=None,
+    )
+    assert t.wb_count("#-") == 2
+
+
+def test_wb_count_with_non_default_boundary_tag():
+    t = Traversal(
+        spec="Beruf°~°s°#°soldat°~°en°#°verein°NN°°Masc°°Dat°°Pl°",
+        surface="Berufssoldatenverein",
+        analysis="Berufssoldatenverein",
+        weights=None,
+        lidx=None,
+        pidx=None,
+        pos="NN",
+        category=None,
+        degree=None,
+        function=None,
+        person=None,
+        gender="Masc",
+        case="Dat",
+        number="Pl",
+        nonfinite=None,
+        tense=None,
+        mood=None,
+        auxiliary=None,
+        inflection=None,
+        metainfo=None,
+        orthinfo=None,
+        charinfo=None,
+        syninfo=None,
+        ellipinfo=None,
+        processes=None,
+        means=None,
+    )
+    assert t.wb_count("#", boundary_tag="°") == 2
+    assert t.wb_count("#~", boundary_tag="°") == 4

--- a/test/test_traversal.py
+++ b/test/test_traversal.py
@@ -63,36 +63,3 @@ def test_wb_count_ignore_symbols_not_in_boundary_tag():
         means=None,
     )
     assert t.wb_count("#-") == 2
-
-
-def test_wb_count_with_non_default_boundary_tag():
-    t = Traversal(
-        spec="Beruf°~°s°#°soldat°~°en°#°verein°NN°°Masc°°Dat°°Pl°",
-        surface="Berufssoldatenverein",
-        analysis="Berufssoldatenverein",
-        weights=None,
-        lidx=None,
-        pidx=None,
-        pos="NN",
-        category=None,
-        degree=None,
-        function=None,
-        person=None,
-        gender="Masc",
-        case="Dat",
-        number="Pl",
-        nonfinite=None,
-        tense=None,
-        mood=None,
-        auxiliary=None,
-        inflection=None,
-        metainfo=None,
-        orthinfo=None,
-        charinfo=None,
-        syninfo=None,
-        ellipinfo=None,
-        processes=None,
-        means=None,
-    )
-    assert t.wb_count("#", boundary_tag="°") == 2
-    assert t.wb_count("#~", boundary_tag="°") == 4


### PR DESCRIPTION
I added a method to the `Traversal` class to count word formation boundaries. For ambiguous cases that are not covered by the ppm table, the `Lemmatizer` makes now use of this count and prefers the analysis with minimal boundary tags.